### PR TITLE
slick 3.2.0 is released

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -162,6 +162,6 @@ object Build extends Build {
   def getSlickDependency(slickComponent: String, version: String): ModuleID = {
     "com.typesafe.slick" %
     (slickComponent + "_" + version.substring(0, version.lastIndexOf('.'))) %
-    (if(version.startsWith("2.12")) {"3.2.0-M2"} else {"3.1.1"})
+    (if(version.startsWith("2.12")) {"3.2.0"} else {"3.1.1"})
   }
 }


### PR DESCRIPTION
Slick 3.2.0 is released so you can use the latest version