### PR TITLE
Entity as trait

### DIFF
--- a/src/main/scala/com/byteslounge/slickrepo/meta/Entity.scala
+++ b/src/main/scala/com/byteslounge/slickrepo/meta/Entity.scala
@@ -27,7 +27,9 @@ package com.byteslounge.slickrepo.meta
 /**
  * Business entity that is mapped to a database record.
  */
-abstract class Entity[T <: Entity[T, ID], ID](val id: Option[ID] = None) {
+trait Entity[T <: Entity[T, ID], ID] {
+
+  val id: Option[ID]
 
   /**
   * Sets the identifier for this entity instance.

--- a/src/main/scala/com/byteslounge/slickrepo/meta/VersionedEntity.scala
+++ b/src/main/scala/com/byteslounge/slickrepo/meta/VersionedEntity.scala
@@ -27,7 +27,9 @@ package com.byteslounge.slickrepo.meta
 /**
  * Versioned business entity that is mapped to a database record.
  */
-abstract class VersionedEntity[T <: VersionedEntity[T, ID, V], ID, V](val version: Option[V] = None) extends Entity[T, ID] {
+trait VersionedEntity[T <: VersionedEntity[T, ID, V], ID, V] extends Entity[T, ID] {
+
+  val version: Option[V]
 
   /**
   * Sets the version for this versioned entity instance.


### PR DESCRIPTION
Making the Entity an abstract class creates limitations of what can be achieved with the entities case classes. The same goal can be achieved without those by converting it to a trait .