### PR TITLE
Increase repository support for composite keys

### DIFF
--- a/src/main/scala/com/byteslounge/slickrepo/repository/Repository.scala
+++ b/src/main/scala/com/byteslounge/slickrepo/repository/Repository.scala
@@ -44,4 +44,8 @@ abstract class Repository[T <: Entity[T, ID], ID](val driver: JdbcProfile) exten
   lazy protected val findOneCompiled = Compiled((id: Rep[ID]) => tableQuery.filter(_.id === id))
 
   override protected def findOneQuery(id: ID): F = findOneCompiled(id)
+
+  override protected lazy val saveQuery: driver.IntoInsertActionComposer[T, ID] =
+    tableQuery returning tableQuery.map(_.id)
+  
 }


### PR DESCRIPTION
I've been exploring a way to add support for entities using composite keys, this is a possible solution to achieve that.

The main change is the removal of the `Keyed` bind away from `BaseRepository` and into the `Repository` class and the delegation of how to find an entity using its id. This then allows the usage of `BaseRepository` independently of how the id is composed. 

The actual implementation of a repository using composite keys was left to the user as, apart from the number of elements, it would be very similar to the one in `Repository`. An implementation for dual composite keys can be included or an example provided if deemed valuable.