### PR TITLE
Set BaseRepository as a trait

### DIFF
--- a/src/main/scala/com/byteslounge/slickrepo/repository/BaseRepository.scala
+++ b/src/main/scala/com/byteslounge/slickrepo/repository/BaseRepository.scala
@@ -37,7 +37,7 @@ import scala.concurrent.ExecutionContext
   * Repository used to execute CRUD operations against a database for
   * a given entity type.
   */
-abstract class BaseRepository[T <: Entity[T, ID], ID] {
+trait BaseRepository[T <: Entity[T, ID], ID] {
 
   protected val driver: JdbcProfile
 


### PR DESCRIPTION
Changes `BaseRepository` from an abstract class to a trait to allow additional flexibility while mixing it.