### PR TITLE
Unify VersionedRepository parameters to match Repository

### DIFF
--- a/src/main/scala/com/byteslounge/slickrepo/repository/Repository.scala
+++ b/src/main/scala/com/byteslounge/slickrepo/repository/Repository.scala
@@ -31,4 +31,4 @@ import com.byteslounge.slickrepo.scalaversion.JdbcProfile
  * Repository used to execute CRUD operations against a database for
  * a given entity type.
  */
-abstract class Repository[T <: Entity[T, ID], ID](val driver: JdbcProfile) extends BaseRepository[T, ID]
+abstract class Repository[T <: Entity[T, ID], ID] extends BaseRepository[T, ID]

--- a/src/main/scala/com/byteslounge/slickrepo/repository/VersionedRepository.scala
+++ b/src/main/scala/com/byteslounge/slickrepo/repository/VersionedRepository.scala
@@ -41,7 +41,7 @@ import scala.concurrent.ExecutionContext
  * Repository used to execute CRUD operations against a database for
  * a given versioned entity type.
  */
-abstract class VersionedRepository[T <: VersionedEntity[T, ID, V], ID, V : VersionGenerator] (override val driver: JdbcProfile) extends Repository[T, ID](driver) {
+abstract class VersionedRepository[T <: VersionedEntity[T, ID, V], ID, V : VersionGenerator] extends Repository[T, ID] {
 
   import driver.api._
 

--- a/src/test/scala/com/byteslounge/slickrepo/repository/CarRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/CarRepository.scala
@@ -32,7 +32,7 @@ case class Car(override val id: Option[Int] = None, brand: String, idPerson: Int
   def withId(id: Int): Car = this.copy(id = Some(id))
 }
 
-class CarRepository(override val driver: JdbcProfile) extends Repository[Car, Int](driver) {
+class CarRepository(override val driver: JdbcProfile) extends Repository[Car, Int] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/CoffeeRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/CoffeeRepository.scala
@@ -32,7 +32,7 @@ case class Coffee(override val id: Option[Int], brand: String) extends Entity[Co
   def withId(id: Int): Coffee = this.copy(id = Some(id))
 }
 
-class CoffeeRepository(override val driver: JdbcProfile) extends Repository[Coffee, Int](driver) {
+class CoffeeRepository(override val driver: JdbcProfile) extends Repository[Coffee, Int] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/CompositeRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/CompositeRepository.scala
@@ -36,7 +36,7 @@ case class Composite(override val id: Option[CompositeId], someField: String) ex
   def withId(id: CompositeId): Composite = this.copy(id = Some(id))
 }
 
-class CompositeRepository(override val driver: JdbcProfile) extends Repository[Composite, CompositeId](driver) {
+class CompositeRepository(override val driver: JdbcProfile) extends Repository[Composite, CompositeId] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[CompositeId]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/PersonRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/PersonRepository.scala
@@ -32,7 +32,7 @@ case class Person(override val id: Option[Int] = None, name: String) extends Ent
   def withId(id: Int): Person = this.copy(id = Some(id))
 }
 
-class PersonRepository(override val driver: JdbcProfile) extends Repository[Person, Int](driver) {
+class PersonRepository(override val driver: JdbcProfile) extends Repository[Person, Int] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/TestInstantVersionedEntityRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/TestInstantVersionedEntityRepository.scala
@@ -34,7 +34,7 @@ case class TestInstantVersionedEntity(override val id: Option[Int], price: Doubl
   def withVersion(version: InstantVersion): TestInstantVersionedEntity = this.copy(version = Some(version))
 }
 
-class TestInstantVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestInstantVersionedEntity, Int, InstantVersion](driver) {
+class TestInstantVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestInstantVersionedEntity, Int, InstantVersion] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/TestIntegerVersionedAutoPkEntityRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/TestIntegerVersionedAutoPkEntityRepository.scala
@@ -33,7 +33,7 @@ case class TestIntegerVersionedAutoPkEntity(override val id: Option[Int], price:
   def withVersion(version: Int): TestIntegerVersionedAutoPkEntity = this.copy(version = Some(version))
 }
 
-class TestIntegerVersionedAutoPkEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestIntegerVersionedAutoPkEntity, Int, Int](driver) {
+class TestIntegerVersionedAutoPkEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestIntegerVersionedAutoPkEntity, Int, Int] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/TestIntegerVersionedEntityRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/TestIntegerVersionedEntityRepository.scala
@@ -33,7 +33,7 @@ case class TestIntegerVersionedEntity(override val id: Option[Int], price: Doubl
   def withVersion(version: Int): TestIntegerVersionedEntity = this.copy(version = Some(version))
 }
 
-class TestIntegerVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestIntegerVersionedEntity, Int, Int](driver) {
+class TestIntegerVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestIntegerVersionedEntity, Int, Int] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/TestJodaTimeVersionedEntityRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/TestJodaTimeVersionedEntityRepository.scala
@@ -37,7 +37,7 @@ case class TestJodaTimeVersionedEntity(override val id: Option[Int], price: Doub
   def withVersion(version: Instant): TestJodaTimeVersionedEntity = this.copy(version = Some(version))
 }
 
-class TestJodaTimeVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestJodaTimeVersionedEntity, Int, Instant](driver) {
+class TestJodaTimeVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestJodaTimeVersionedEntity, Int, Instant] {
 
   import driver.api._
 

--- a/src/test/scala/com/byteslounge/slickrepo/repository/TestLocalDateTimeVersionedEntityRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/TestLocalDateTimeVersionedEntityRepository.scala
@@ -34,7 +34,7 @@ case class TestLocalDateTimeVersionedEntity(override val id: Option[Int], price:
   def withVersion(version: LocalDateTimeVersion): TestLocalDateTimeVersionedEntity = this.copy(version = Some(version))
 }
 
-class TestLocalDateTimeVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestLocalDateTimeVersionedEntity, Int, LocalDateTimeVersion](driver) {
+class TestLocalDateTimeVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestLocalDateTimeVersionedEntity, Int, LocalDateTimeVersion] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/TestLongInstantVersionedEntityRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/TestLongInstantVersionedEntityRepository.scala
@@ -34,7 +34,7 @@ case class TestLongInstantVersionedEntity(override val id: Option[Int], price: D
   def withVersion(version: LongInstantVersion): TestLongInstantVersionedEntity = this.copy(version = Some(version))
 }
 
-class TestLongInstantVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestLongInstantVersionedEntity, Int, LongInstantVersion](driver) {
+class TestLongInstantVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestLongInstantVersionedEntity, Int, LongInstantVersion] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/TestLongLocalDateTimeVersionedEntityRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/TestLongLocalDateTimeVersionedEntityRepository.scala
@@ -34,7 +34,7 @@ case class TestLongLocalDateTimeVersionedEntity(override val id: Option[Int], pr
   def withVersion(version: LongLocalDateTimeVersion): TestLongLocalDateTimeVersionedEntity = this.copy(version = Some(version))
 }
 
-class TestLongLocalDateTimeVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestLongLocalDateTimeVersionedEntity, Int, LongLocalDateTimeVersion](driver) {
+class TestLongLocalDateTimeVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestLongLocalDateTimeVersionedEntity, Int, LongLocalDateTimeVersion] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/TestLongVersionedEntityRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/TestLongVersionedEntityRepository.scala
@@ -33,7 +33,7 @@ case class TestLongVersionedEntity(override val id: Option[Int], price: Double, 
   def withVersion(version: Long): TestLongVersionedEntity = this.copy(version = Some(version))
 }
 
-class TestLongVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestLongVersionedEntity, Int, Long](driver) {
+class TestLongVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[TestLongVersionedEntity, Int, Long] {
 
   import driver.api._
   val pkType = implicitly[BaseTypedType[Int]]

--- a/src/test/scala/com/byteslounge/slickrepo/repository/UserRepository.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/repository/UserRepository.scala
@@ -54,7 +54,7 @@ case class User(
 }
 
 abstract class PersistableRepository[T <: Persistable[T] with Entity[T, ID], ID](override val driver: JdbcProfile)
-  extends Repository[T, ID](driver) {
+  extends Repository[T, ID] {
 
   @prePersist
   private def prePersist(entity: T): T = {

--- a/src/test/scala/com/byteslounge/slickrepo/test/RepositoryLifecycleEventsTest.scala
+++ b/src/test/scala/com/byteslounge/slickrepo/test/RepositoryLifecycleEventsTest.scala
@@ -277,7 +277,7 @@ case class LifecycleEntity(override val id: Option[Int] = None, name: String, fi
   def withId(id: Int): LifecycleEntity = this.copy(id = Some(id))
 }
 
-abstract class LifecycleEntityRepository(override val driver: JdbcProfile) extends Repository[LifecycleEntity, Int](driver) {
+abstract class LifecycleEntityRepository(override val driver: JdbcProfile) extends Repository[LifecycleEntity, Int] {
 
   import driver.api._
 
@@ -303,7 +303,7 @@ case class LifecycleEntityManualPk(override val id: Option[Int], name: String, f
   def withId(id: Int): LifecycleEntityManualPk = this.copy(id = Some(id))
 }
 
-class LifecycleEntityRepositoryManualPk(override val driver: JdbcProfile) extends Repository[LifecycleEntityManualPk, Int](driver) {
+class LifecycleEntityRepositoryManualPk(override val driver: JdbcProfile) extends Repository[LifecycleEntityManualPk, Int] {
 
   import driver.api._
 
@@ -416,7 +416,7 @@ case class LifecycleVersionedEntity(override val id: Option[Int] = None, name: S
   def withVersion(version: Int): LifecycleVersionedEntity = this.copy(version = Some(version))
 }
 
-abstract class LifecycleVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[LifecycleVersionedEntity, Int, Int](driver) {
+abstract class LifecycleVersionedEntityRepository(override val driver: JdbcProfile) extends VersionedRepository[LifecycleVersionedEntity, Int, Int] {
 
   import driver.api._
 
@@ -445,7 +445,7 @@ case class LifecycleVersionedEntityManualPk(override val id: Option[Int] = None,
   def withVersion(version: Int): LifecycleVersionedEntityManualPk = this.copy(version = Some(version))
 }
 
-class LifecycleVersionedEntityRepositoryManualPk(override val driver: JdbcProfile) extends VersionedRepository[LifecycleVersionedEntityManualPk, Int, Int](driver) {
+class LifecycleVersionedEntityRepositoryManualPk(override val driver: JdbcProfile) extends VersionedRepository[LifecycleVersionedEntityManualPk, Int, Int] {
 
   import driver.api._
 


### PR DESCRIPTION
This PR unifies the two repos provided by `slick-repo` (`Repository` and `VersionedRepository`) by removing the `driver` parameter from `VersionedRepository`.

As a side effect, this change also helps integrating with Play Framework's `HasDatabaseConfigProvider` trait, where both `VersionedRepository` of `slick-repo` and `HasDatabaseConfigProvider` of Play define a `driver` with different scope modifiers (which results in a compilation error).